### PR TITLE
Move float and integer out of CSV into Parse (inter replaces number)

### DIFF
--- a/examples/packages.csv
+++ b/examples/packages.csv
@@ -2,5 +2,5 @@ repo,alias,version
 imclerran/roc-ai,ai,0.10.1
 imclerran/roc-asciiart,art,0.2.0
 imclerran/roc-isodate,iso,0.6.0
-imclerran/roc-tinyparse,parse,0.1.2
+imclerran/roc-tinyparse,parse,0.2.0
 imclerran/roc-utf16,utf16,0.2.0

--- a/package/CSV.roc
+++ b/package/CSV.roc
@@ -1,8 +1,7 @@
 ## This module contains parsers specifically for parsing csv files
-module [comma, newline, float, integer, csv_string]
+module [comma, newline, csv_string]
 
-import Parse exposing [Parser, number, char, maybe, string, rhs, lhs, both, map, one_or_more, excluding, filter, one_of, finalize]
-import Utils exposing [int_pair_to_float, approx_eq]
+import Parse exposing [Parser, char, string, rhs, lhs, map, one_or_more, excluding, filter, one_of, finalize]
 
 ## Match a comma character
 comma : Parser U8 [CommaNotFound]
@@ -19,32 +18,6 @@ newline = |str|
     parser(str) |> Result.map_err(|_| NewlineNotFound)
 
 expect newline("\n") |> finalize == Ok('\n')
-
-## Match an integer number
-integer : Parser U64 [InvalidInteger]
-integer = |str| number(str) |> Result.map_err(|_| InvalidInteger)
-
-expect integer("123") == Ok((123, ""))
-
-## Match a floating point number
-float : Parser F64 [InvalidFloat]
-float = |str|
-    parser = number |> both(maybe(string(".") |> rhs(number))) |> map(|(l, maybe_r)|
-        when maybe_r is
-            None -> Ok(Num.to_f64(l))
-            Some(r) -> Ok(int_pair_to_float(l, r))
-    )
-    parser(str) |> Result.map_err(|_| InvalidFloat)
-
-expect
-    import Unsafe
-    res = float("123.456789") |> Unsafe.unwrap("Failed to parse float")
-    approx_eq(res.0, 123.456789)
-
-expect
-    import Unsafe
-    res = float("123") |> Unsafe.unwrap("Failed to parse float")
-    approx_eq(res.0, 123)
 
 ## Match a string with or without quotation marks
 csv_string : Parser Str [InvalidString]


### PR DESCRIPTION
`CSV.integer` was redundant with `Parse.number`, and `number` was an inaccurate descriptor for that parser. Since float and integer are both commonly needed outside CSVs, these were both moved into Parse.

Also added many tests for previously untested combinators.